### PR TITLE
fix: Add dynamic page title

### DIFF
--- a/src/Copy/Keys.elm
+++ b/src/Copy/Keys.elm
@@ -4,6 +4,17 @@ module Copy.Keys exposing (Key(..))
 type Key
     = --- Site Meta
       SiteTitle
+    | DesktopTitle
+    | DocumentsTitle
+    | DocumentTitle String
+    | EmailsTitle
+    | EmailTitle String
+    | MessagesTitle
+    | SocialTitle
+    | IntroTitle
+    | LandingTitle
+    | EndInfoTitle
+    | PathCheckerTitle
       --- Route Slugs
     | Navbar
     | DesktopSlug

--- a/src/Copy/Text.elm
+++ b/src/Copy/Text.elm
@@ -10,9 +10,42 @@ import Copy.Keys exposing (Key(..))
 t : Key -> String
 t key =
     case key of
-        -- Meta
+        -- Meta [cCc]
         SiteTitle ->
             "Welcome to BioCore"
+
+        DesktopTitle ->
+            "Biocore Desktop"
+
+        DocumentsTitle ->
+            "Biocore Documents"
+
+        DocumentTitle id ->
+            "Biocore Document | " ++ id
+
+        EmailsTitle ->
+            "Biocore Emails"
+
+        EmailTitle id ->
+            "Biocore Email | " ++ id
+
+        MessagesTitle ->
+            "Biocore Messages"
+
+        SocialTitle ->
+            "Biocore Tweeeeter"
+
+        IntroTitle ->
+            "Welcome to Biocore"
+
+        LandingTitle ->
+            "Welcome to Biocore"
+
+        EndInfoTitle ->
+            "Biocore - Thank You"
+
+        PathCheckerTitle ->
+            "Path Checker"
 
         -- Slugs
         Navbar ->

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -395,7 +395,44 @@ updatePathChecker model ( pathChecker, cmds ) =
 
 viewDocument : Model -> Browser.Document Msg
 viewDocument model =
-    { title = t SiteTitle, body = [ view model ] }
+    { title = t (titleKeyFromPage model.page), body = [ view model ] }
+
+
+titleKeyFromPage : Route -> Key
+titleKeyFromPage page =
+    case page of
+        Desktop ->
+            DesktopTitle
+
+        Documents ->
+            DocumentsTitle
+
+        Document id ->
+            DocumentTitle id
+
+        Emails ->
+            EmailsTitle
+
+        Email id ->
+            EmailTitle id
+
+        Messages ->
+            MessagesTitle
+
+        Social ->
+            SocialTitle
+
+        Intro ->
+            IntroTitle
+
+        EndInfo ->
+            EndInfoTitle
+
+        Landing ->
+            LandingTitle
+
+        PathChecker _ ->
+            PathCheckerTitle
 
 
 view : Model -> Html Msg


### PR DESCRIPTION
Fixes #242

## Description

- Add meta page titles
- Could be inproved by using title rather than id, or just removing id?  Left a [cCc] tag in to remind us to review all of these meta titles

- @Nikomus thoughts

@TheLabCollective/developers
