### PR TITLE
Re-jig intro video flow

### DIFF
--- a/src/Copy/Keys.elm
+++ b/src/Copy/Keys.elm
@@ -67,8 +67,6 @@ type Key
     | EndInfoParagraph4
       --- Ending info
     | LandingParagraph
-    | LandingVideo
-    | LandingVideoIframeTitle
     | LandingLinkText
       --- TeamNames
     | TeamNames

--- a/src/Copy/Keys.elm
+++ b/src/Copy/Keys.elm
@@ -17,10 +17,9 @@ type Key
     | PathCheckerSlug
     | UploadPath
       --- Intro page
-    | WatchIntro1
-    | WatchIntro2
-    | WatchIntro3
-    | StartNewGame
+    | WatchIntro3Button
+    | SkipIntro3VideoLink
+    | StartNewGameLink
       --- Navigation text
     | NavDocuments
     | NavEmails

--- a/src/Copy/Text.elm
+++ b/src/Copy/Text.elm
@@ -53,17 +53,14 @@ t key =
             "Watch Video"
 
         -- Intro page
-        WatchIntro1 ->
-            "Watch Welcome Video"
+        WatchIntro3Button ->
+            "YOUR ASSIGNMENT"
 
-        WatchIntro2 ->
-            "Watch Protocol Video"
+        SkipIntro3VideoLink ->
+            "JUMP RIGHT IN"
 
-        WatchIntro3 ->
-            "Watch Next Steps Video"
-
-        StartNewGame ->
-            "Begin Ethical Review"
+        StartNewGameLink ->
+            "BEGIN ETHICAL REVIEW"
 
         NavDocuments ->
             "Documents"

--- a/src/Copy/Text.elm
+++ b/src/Copy/Text.elm
@@ -208,13 +208,6 @@ t key =
         LandingParagraph ->
             "This game uses Google Analytics to improve your experience. By entering BioCore, you agree to Google Analytics cookies being placed on your device."
 
-        LandingVideo ->
-            "https://www.youtube.com/embed/YgEEqV6unQ0?autoplay=1&controls=0&rel=0"
-
-        -- This is advised to match the title of the embedded document
-        LandingVideoIframeTitle ->
-            "[cCc] clip12 - YouTube"
-
         LandingLinkText ->
             "ENTER BIOCORE"
 

--- a/src/Video.elm
+++ b/src/Video.elm
@@ -4,7 +4,6 @@ module Video exposing (Video(..), embedUrlFromIdString, videoToData)
 type Video
     = Landing
     | Intro1
-    | Intro2
     | Intro3
     | EndMessage
 
@@ -17,9 +16,6 @@ videoToData video =
 
         Intro1 ->
             { id = "mvo5p86uYNc", title = "Welcome to Biocore - YouTube" }
-
-        Intro2 ->
-            { id = "zDvg0tnHc0Q", title = "Protocol - YouTube" }
 
         Intro3 ->
             { id = "qCv6EkEG5sQ", title = "Next Steps - YouTube" }

--- a/src/View/Intro.elm
+++ b/src/View/Intro.elm
@@ -17,34 +17,30 @@ view activeVideo =
         [ div [ class "row my-4" ]
             [ h1 [ class "d-block mx-auto px-4 text-center" ] [ text (t SiteTitle) ]
             ]
-        , div [ class "intro-video" ] [ View.Video.view (videoToData activeVideo) ]
-        , renderVideoButtons
-        , div [ class "row my-4" ]
-            [ a
+        , div [ class "intro-video" ]
+            [ View.Video.view (videoToData activeVideo) ]
+        , div [ class "row my-4 video-button-row" ]
+            [ if activeVideo == Intro1 then
+                button
+                    [ class "btn btn-primary btn-lg mx-auto"
+                    , type_ "button"
+                    , onClick (WatchIntroVideoClicked Intro3)
+                    ]
+                    [ text (t WatchIntro3Button) ]
+
+              else
+                text ""
+            , a
                 [ class "btn btn-primary btn-lg mx-auto"
                 , href (Route.toString Route.Desktop)
                 ]
-                [ text (t StartNewGame) ]
+                [ text
+                    (if activeVideo == Intro3 then
+                        t StartNewGameLink
+
+                     else
+                        t SkipIntro3VideoLink
+                    )
+                ]
             ]
         ]
-
-
-renderVideoButtons : Html Msg
-renderVideoButtons =
-    ol [ class "row my-4 list-unstyled video-button-list" ]
-        (List.map
-            (\( buttonTextKey, videoKey ) ->
-                li [ class "col text-center" ]
-                    [ button
-                        [ class "btn btn-primary btn-md mx-2"
-                        , type_ "button"
-                        , onClick (WatchIntroVideoClicked videoKey)
-                        ]
-                        [ text (t buttonTextKey) ]
-                    ]
-            )
-            [ ( WatchIntro1, Intro1 )
-            , ( WatchIntro2, Intro2 )
-            , ( WatchIntro3, Intro3 )
-            ]
-        )

--- a/src/styles/video.scss
+++ b/src/styles/video.scss
@@ -17,19 +17,20 @@
   max-width: 800px;
 }
 
-.video-button-list {
+.video-button-row {
   display: flex;
   flex-direction: row;
   margin: auto;
   max-width: 800px;
 
-  li button {
-    width: 200px;
+  a,
+  button {
+    width: 280px;
   }
 }
 
 @media (max-width: 767px) {
-  .video-button-list {
+  .video-button-row {
     flex-direction: column;
     gap: 1rem;
   }


### PR DESCRIPTION
Fixes #257 

## Description

- Watch assignment video or jump right in
- Remove protocol video from intro

@TheLabCollective/developers

@Nikomus I tried to do the least amount of work possible in changing this. As a result, you can get back to the Intro video only with back button once you have pressed assignment and the game button is still the Ethical review one. I am ok with this as we encourage people to move forward through the game.

Created #260 to address the Your assignment doc & it's visited stete (we can add to visited list when "Begin Ethical Review" button pressed)